### PR TITLE
[FIX] change package name to winglink in entities

### DIFF
--- a/backend/src/main/java/com/winglink/backend/entity/Airport.java
+++ b/backend/src/main/java/com/winglink/backend/entity/Airport.java
@@ -1,4 +1,4 @@
-package com.example.backend.entity;
+package com.winglink.backend.entity;
 
 import jakarta.persistence.*;
 
@@ -14,7 +14,6 @@ public class Airport {
     private String country;
     private String city;
 
-    // Getters and Setters
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/winglink/backend/entity/Flight.java
+++ b/backend/src/main/java/com/winglink/backend/entity/Flight.java
@@ -1,4 +1,4 @@
-package com.example.backend.entity;
+package com.winglink.backend.entity;
 
 import jakarta.persistence.*;
 import java.math.BigDecimal;


### PR DESCRIPTION
Found two more occurrences of invalid package name in `Airport` & `Flight` entity. Changed example to winglink